### PR TITLE
Handle false EPERM errors on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform)
+  this.__isWin = (options && options.isWin) || (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform);
+  this.__isWin = (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)
@@ -92,7 +92,7 @@ function handleClose (writeStream) {
       writeStream.emit('close')
     })
   }
-  function trapWindowsEPERMRename(err) {
+  function trapWindowsEPERMRename (err) {
     if (err.syscall && err.syscall === 'rename' &&
         err.code && err.code === 'EPERM' &&
         writeStream.__isWin
@@ -101,11 +101,11 @@ function handleClose (writeStream) {
       // if the target file exists, we can ignore the EPERM error
       if (fs.existsSync(writeStream.__atomicTarget)) {
         // a little janky, call end() directly
-        return end();
+        return end()
       }
     }
 
-    cleanup(err);
+    cleanup(err)
   }
   function moveIntoPlace () {
     fs.rename(writeStream.__atomicTmp, writeStream.__atomicTarget, iferr(trapWindowsEPERMRename, end))

--- a/test/rename-eperm.js
+++ b/test/rename-eperm.js
@@ -1,0 +1,49 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-rename-eperm')
+
+test('rename eperm', function (t) {
+  t.plan(2)
+
+  var _rename = fs.rename
+  fs.existsSync = function (src) {
+    return true
+  }
+  fs.rename = function (src, dest, cb) {
+    // simulate a failure during rename where the file
+    // is renamed successfully but the process encounters
+    // an EPERM error
+    _rename(src, dest, function (e) {
+      var err = new Error('TEST BREAK')
+      err.syscall = 'rename'
+      err.code = 'EPERM'
+      cb(err)
+    })
+  }
+
+  var stream = writeStream(target, { isWin: true })
+  var hadError = false
+  var calledFinish = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('finish', function () {
+    calledFinish = true
+  })
+  stream.on('close', function () {
+    t.is(hadError, false, 'error was caught')
+    t.is(calledFinish, true, 'finish was called before close')
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})


### PR DESCRIPTION
this PR prevents bad EPERM errors from bubbling up on windows. this is related to https://github.com/npm/npm/pull/12333. Very often we'll see EPERM failures when npm tries to populate tarballs into the cache on our continuous integration systems. After checking the cache directory we'll see that the tarball does in fact exist and is valid.

this PR updates fs-write-stream-atomic to not throw EPERM errors on rename if we're on windows and the target file exists.